### PR TITLE
change: EntryServerが複数のFileServerを持てるように変更

### DIFF
--- a/src/server/EntryServer.java
+++ b/src/server/EntryServer.java
@@ -52,14 +52,24 @@ public class EntryServer {
     private static final Map<String, FileServer> fileServers = new HashMap<>();
 
     private static void initFileServers() {
-        String fsRoot = System.getenv("FS_ROOT");
-        if (fsRoot == null) {
-            System.out.println("FS_ROOT is not set");
-            System.exit(1);
-        }
+        System.out.println("Setting up local file servers ...");
+        final String SERVER_HOSTNAME_BASE = "localhost";
 
-        FileServer a = new FileServer(Paths.get(fsRoot));
-        fileServers.put("localhost", a);
+        for (int i = 0; ; i++) {
+            String fsRoot = System.getenv(String.format("FS_ROOT_%d", i));
+            if (fsRoot == null) {
+                if (i == 0) {
+                    System.out.println("FS_ROOT_0 has to be set.");
+                    System.exit(1);
+                } else {
+                    break;
+                }
+            }
+
+            FileServer fs = new FileServer(Paths.get(fsRoot));
+            fileServers.put(SERVER_HOSTNAME_BASE + i, fs);
+            System.out.println(String.format("Registered: %s -> %s", SERVER_HOSTNAME_BASE + i, fsRoot));
+        }
     }
 
     /**


### PR DESCRIPTION
# 変更
- 必要な環境変数名の変更
  - これまで`FS_ROOT`を参照してFileServerのルートディレクトリを決めていたが、FileServerのインスタンスを複数建てられるように変更したことに合わせて、`FS_ROOT_[数字]`という名称の環境変数を参照するように変更。
  - 単一のFIleServerを扱いたいときは、`FS_ROOT`ではなく`FS_ROOT_0`にルートのパスを設定することになる。
  - 各FileServerのファイルにアクセスしたいときには、ホスト名として`localhost[数字]`を指定する。
    - `FS_ROOT_0`をルートとするサーバーのホスト名は`localhost0`、`FS_ROOT_1`をルートとするサーバーのホスト名は`localhost1`、という命名になっている。
 
`EntryServer`の`initFileServers()`しか編集してないので変なコンフリクトとかは起こらないと思います。